### PR TITLE
Create and Fix JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,6 @@ ant.importBuild("sherrloc/GenErrorDiagnostic/build.xml") {
 
 repositories {
     mavenCentral()
-    flatDir {
-        dirs "build/libs"
-    }
 }
 
 sourceSets {
@@ -71,7 +68,7 @@ def fatJar = tasks.register("fatJar", Jar) {
 
     archiveBaseName = "SCIF-full"
 
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }


### PR DESCRIPTION
This is a pretty hacky fix to make the JAR run. The codebase currently relies heavily on file paths and File objects. However, the files in Gradle resources are not directly accessible as files; rather, they have to be read as resources. So, we create temporary files.

There are also some annoying problems with #5. In some cases it breaks compilation; in other cases, it breaks at runtime. We change the duplicate strategy to solve the runtime java.lang.NoSuchMethodError.